### PR TITLE
reliability fixes

### DIFF
--- a/m/tdoa_plot_dt.m
+++ b/m/tdoa_plot_dt.m
@@ -69,8 +69,12 @@ function tdoa=tdoa_plot_dt(input, tdoa, plot_info, dt)
       hold off;
       printf('tdoa_plot_dt(%d,%d) %.2f sec\n', i,j, toc());
       if plot_kiwi
-        print('-dpng','-S1024,690', sprintf('%s/%s-%s dt.png', plot_info.dir, input(i).fname, input(j).fname));
-        print('-dpdf','-S1024,690', sprintf('%s/%s-%s dt.pdf', plot_info.dir, input(i).fname, input(j).fname));
+        try
+          print('-dpng','-S1024,690', sprintf('%s/%s-%s dt.png', plot_info.dir, input(i).fname, input(j).fname));
+          print('-dpdf','-S1024,690', sprintf('%s/%s-%s dt.pdf', plot_info.dir, input(i).fname, input(j).fname));
+        catch
+          tdoa_err_kiwi(7);
+        end_try_catch
       end
     end
   end

--- a/m/tdoa_plot_map.m
+++ b/m/tdoa_plot_map.m
@@ -74,18 +74,28 @@ function tdoa=tdoa_plot_map(input_data, tdoa, plot_info)
         plot_location(plot_info, input_data(i).coord, input_data(i).name, false);
         plot_location(plot_info, input_data(j).coord, input_data(j).name, false);
         set(colorbar(), 'XLabel', '\sigma')
-        print(sprintf('%s/%s-%s map.png', plot_info.dir, input_data(i).fname, input_data(j).fname), ...
-              '-dpng', '-S1024,690');
-        print(sprintf('%s/%s-%s map.pdf', plot_info.dir, input_data(i).fname, input_data(j).fname), ...
-              '-dpng', '-S1024,690');
-        [bb_lon, bb_lat] = save_as_png_for_map(plot_info,
-                                               sprintf('%s/%s-%s_for_map.png', plot_info.dir, input_data(i).fname, input_data(j).fname),
-                                               h);
-
-        [_,h]=contour(plot_info.lon, plot_info.lat, h, [1 3 5 10 15], '--', 'linecolor', 0.7*[1 1 1]);
-        save_as_json_for_map(sprintf('%s/%s-%s_contour_for_map.json', plot_info.dir, input_data(i).fname, input_data(j).fname),
-                             sprintf('%s/%s-%s_for_map.png', plot_info.dir, input_data(i).fname, input_data(j).fname),
-                             h, bb_lon, bb_lat, plot_info, ~false);
+        try
+          print(sprintf('%s/%s-%s map.png', plot_info.dir, input_data(i).fname, input_data(j).fname), ...
+                '-dpng', '-S1024,690');
+          print(sprintf('%s/%s-%s map.pdf', plot_info.dir, input_data(i).fname, input_data(j).fname), ...
+                '-dpng', '-S1024,690');
+        catch
+          tdoa_err_kiwi(5);
+        end_try_catch
+        if isfield(plot_info, 'plot_kiwi_json')
+          try
+            [bb_lon, bb_lat] = save_as_png_for_map(plot_info,
+                                                   sprintf('%s/%s-%s_for_map.png', plot_info.dir, input_data(i).fname, input_data(j).fname),
+                                                   h);
+    
+            [_,h]=contour(plot_info.lon, plot_info.lat, h, [1 3 5 10 15], '--', 'linecolor', 0.7*[1 1 1]);
+            save_as_json_for_map(sprintf('%s/%s-%s_contour_for_map.json', plot_info.dir, input_data(i).fname, input_data(j).fname),
+                                 sprintf('%s/%s-%s_for_map.png', plot_info.dir, input_data(i).fname, input_data(j).fname),
+                                 h, bb_lon, bb_lat, plot_info, ~false);
+          catch
+            tdoa_err_kiwi(8);
+          end_try_catch
+        end
       end
     end
   end
@@ -151,13 +161,23 @@ function tdoa=tdoa_plot_map(input_data, tdoa, plot_info)
     print('-dpng','-S900,600', fullfile('png', sprintf('%s.png', plot_info.plotname)));
     print('-dpdf','-S900,600', fullfile('pdf', sprintf('%s.pdf', plot_info.plotname)));
   else
-    print('-dpng','-S1024,690', sprintf('%s/%s.png', plot_info.dir, plot_info.plotname));
-    print('-dpdf','-S1024,690', sprintf('%s/%s.pdf', plot_info.dir, plot_info.plotname));
-    [bb_lon, bb_lat] = save_as_png_for_map(plot_info, sprintf('%s/%s_for_map.png', plot_info.dir, plot_info.plotname), h);
-    [_,h]=contour(plot_info.lon, plot_info.lat, h, [1 3 5 10 15], '--', 'linecolor', 0.7*[1 1 1]);
-    save_as_json_for_map(sprintf('%s/%s_contour_for_map.json', plot_info.dir, plot_info.plotname),
-                         sprintf('%s/%s_for_map.png', plot_info.dir, plot_info.plotname),
-                         h, bb_lon, bb_lat, plot_info, true);
+    try
+      print('-dpng','-S1024,690', sprintf('%s/%s.png', plot_info.dir, plot_info.plotname));
+      print('-dpdf','-S1024,690', sprintf('%s/%s.pdf', plot_info.dir, plot_info.plotname));
+    catch
+      tdoa_err_kiwi(6);
+    end_try_catch
+    if isfield(plot_info, 'plot_kiwi_json')
+      try
+        [bb_lon, bb_lat] = save_as_png_for_map(plot_info, sprintf('%s/%s_for_map.png', plot_info.dir, plot_info.plotname), h);
+        [_,h]=contour(plot_info.lon, plot_info.lat, h, [1 3 5 10 15], '--', 'linecolor', 0.7*[1 1 1]);
+        save_as_json_for_map(sprintf('%s/%s_contour_for_map.json', plot_info.dir, plot_info.plotname),
+                             sprintf('%s/%s_for_map.png', plot_info.dir, plot_info.plotname),
+                             h, bb_lon, bb_lat, plot_info, true);
+      catch
+        tdoa_err_kiwi(8);
+      end_try_catch
+    end
   end
 endfunction
 

--- a/proc_tdoa_kiwi.m
+++ b/proc_tdoa_kiwi.m
@@ -28,13 +28,19 @@ function [tdoa,input]=proc_tdoa_kiwi(dir, files, plot_info)
   plot_info.plotname  = 'TDoA map';
   plot_info.title     = sprintf('%g kHz %s', input(1).freq, input(1).time);
   plot_info.plot_kiwi = true;
-  plot_info.coastlines = 'coastline/world_110m.mat';
 
-  ### determine map resolution and create plot_info.lat and plot_info.lon fields
-  # plot_info = tdoa_autoresolution(plot_info);
-
-  tdoa = tdoa_plot_map_kiwi(input, tdoa, plot_info);
-  tdoa = tdoa_plot_dt_kiwi (input, tdoa, plot_info, 2.5e-3);
+  if isfield(plot_info, 'plot_kiwi_json')
+    ### determine map resolution and create plot_info.lat and plot_info.lon fields
+    plot_info = tdoa_autoresolution(plot_info);
+    tdoa = tdoa_plot_map(input, tdoa, plot_info);
+    tdoa = tdoa_plot_dt (input, tdoa, plot_info, 2.5e-3);
+  else
+    plot_info.coastlines = 'coastline/world_110m.mat';
+    ##tdoa = tdoa_plot_map_kiwi(input, tdoa, plot_info);
+    ##tdoa = tdoa_plot_dt_kiwi (input, tdoa, plot_info, 2.5e-3);
+    tdoa = tdoa_plot_map(input, tdoa, plot_info);
+    tdoa = tdoa_plot_dt (input, tdoa, plot_info, 2.5e-3);
+  end
 
   tdoa_err_kiwi(0);
 endfunction


### PR DESCRIPTION
1. Don’t compute contours when using old non-plot_kiwi_json mode
because for low map zoom find_bounding_box() gets an exception.
Contours aren’t used in this mode anyway.

2. But when using plot_kiwi_json mode return a separate status code
when find_bounding_box() fails.

3. Use try/catch around print() calls to catch failures in the plotting
package and report as a separate status return code.